### PR TITLE
lookup-create-app-version.js: add retry loop for fetching manifest

### DIFF
--- a/lookup-create-app-version.js
+++ b/lookup-create-app-version.js
@@ -1,23 +1,13 @@
-const spawn = require('child_process').spawn;
+const FETCH_ATTEMPT_COUNT = 20;
+const FETCH_ATTEMPT_SLEEP_MS = 3000;
 
-async function getCreateAppVersion(inputVersion) {
-  // This is the old flow, where versions up to 0.4.x are considered to be direct create-app versions
-  const [major, minor] = inputVersion.split('.');
-  if (major === '0' && ['1', '2', '3', '4'].includes(minor)) {
-    return inputVersion;
-  }
-
-  // The new flow is to go look up the release manifest to grab the create-app version
-  const manifest = await new Promise((resolve, reject) => {
-    const url = `https://versions.backstage.io/v1/releases/${inputVersion}/manifest.json`;
+async function fetchManifest(version) {
+  return await new Promise((resolve, reject) => {
+    const url = `https://versions.backstage.io/v1/releases/${version}/manifest.json`;
     require('https')
       .get(url, (res) => {
         if (res.statusCode !== 200) {
-          reject(
-            new Error(
-              `Failed to fetch manifest for ${inputVersion}, ${res.statusCode}`
-            )
-          );
+          reject(new Error(`Fetch failed with status ${res.statusCode}`));
           return;
         }
 
@@ -30,6 +20,34 @@ async function getCreateAppVersion(inputVersion) {
       })
       .on('error', reject);
   });
+}
+
+async function getCreateAppVersion(inputVersion) {
+  // This is the old flow, where versions up to 0.4.x are considered to be direct create-app versions
+  const [major, minor] = inputVersion.split('.');
+  if (major === '0' && ['1', '2', '3', '4'].includes(minor)) {
+    return inputVersion;
+  }
+
+  // The new flow is to go look up the release manifest to grab the create-app version
+  // In case the manifest isn't available yet, we'll retry for a while
+  let manifest;
+  for (let attempt = 1; attempt <= FETCH_ATTEMPT_COUNT; attempt++) {
+    try {
+      manifest = await fetchManifest(inputVersion);
+      break;
+    } catch (error) {
+      console.error(
+        `Failed attempt ${attempt} to fetch manifest for ${inputVersion}, ${error}`
+      );
+      await new Promise((resolve) =>
+        setTimeout(resolve, FETCH_ATTEMPT_SLEEP_MS)
+      );
+    }
+  }
+  if (!manifest) {
+    throw new Error(`Gave up trying to fetch manifest for ${inputVersion}`);
+  }
 
   const createAppEntry = manifest.packages.find(
     (p) => p.name === '@backstage/create-app'


### PR DESCRIPTION
Manifest may not be available immediately, even though we delay the workflow dispatch until after the manifest repo has been updated. Probably due to delay in the publishing of GitHub pages.

This adds a retry loop that keeps trying to fetch the manifest for a minute before giving up. Seemed simpler to do this rather than setting up credentials and fetching via the API.